### PR TITLE
Remove tags section in Docker manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,4 @@
 image: aziotedgetooling.azurecr.io/public/azureiotedge-testing-utility:1.0.0
-tags: [1.0.0-amd64, 1.0.0-windows-amd64, 1.0.0-arm32v7]
 manifests:
   -
     image: aziotedgetooling.azurecr.io/public/azureiotedge-testing-utility:1.0.0-amd64


### PR DESCRIPTION
Remove `tags` section in the manifest so that the tags listed in that section are not overwritten with the content of the manifest.

If the tags are overwritten with the manifest, future update to the manifest will fail with error "You specified a manifest list entry from a digest that points to a current manifest list. Manifest lists do not allow recursion".

See https://github.com/estesp/manifest-tool/pull/32 for the usage of `tags`. The sample manifest in https://github.com/estesp/manifest-tool#createpush also does not have a `tags` section.