### PR TITLE
Allow JSON data

### DIFF
--- a/src/utilityModule.js
+++ b/src/utilityModule.js
@@ -95,7 +95,7 @@ function getValidateMessage(requestBody) {
     throw new Error('Cannot find message data in request body');
   }
 
-  const message = new Message(data);
+  const message = new Message(JSON.stringify(data));
   if(requestBody.properties && typeof requestBody.properties === 'object') {
     const properties = requestBody.properties;
     for(const property in properties) {

--- a/test/testserver.js
+++ b/test/testserver.js
@@ -35,7 +35,7 @@ describe('server', () => {
         .end((err, res) => {
           assert(stub.calledOnce);
           assert.equal(stub.args[0][0], 'input1');
-          assert.equal(stub.args[0][1]['data'], 'Hello World');
+          assert.equal(stub.args[0][1]['data'], JSON.stringify('Hello World'));
           assert.equal(stub.args[0][1]['messageId'], '0');
           assert.equal(stub.args[0][1]['correlationId'], '1');
           res.should.have.status(202);


### PR DESCRIPTION
Fix issue: Error when sending JSON data #12

Allow JSON data to be sent to the messages endpoint. 